### PR TITLE
Add credentials to auth-store fetch

### DIFF
--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -366,6 +366,7 @@ const setServerSession = async (user: UserInfo | null, isAuthenticated: boolean)
     const response = await fetch('/api/user/session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({
         user,
         isAuthenticated,
@@ -399,6 +400,7 @@ const setServerToken = async (token: string | null, refreshToken: string | null)
     const response = await fetch('/api/user/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({
         token,
         refreshToken,


### PR DESCRIPTION
## Summary
- include cookies when setting server session
- include cookies when storing tokens on server

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e300094688323ae0431506a7bff34